### PR TITLE
Improve UX when no results are returned

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,43 +250,48 @@ class Loader {
     const contents = this.db.exec(sql)
     let index = 0;
     let columns = []
-    for(let column of contents[0].columns) {
-      columns.push(column)
-    }
-    let properties = []
-    for(let i=0; i<contents[0].values.length; i++) {
-      let values = contents[0].values[i];
-      let o = { attributes: {} }
-      for(let j=0; j<columns.length; j++) {
-        let column = columns[j]
-        if (["id", "name", "description", "image", "blockHash", "blockNumber", "self", "transactionHash", "uri"].includes(column)) {
-          o[column] = values[j]
-        } else {
-          o.attributes[column] = values[j]
+    var html = ""
+    if (contents.length === 0) {
+      html = "No results"
+    } else {
+      for(let column of contents[0].columns) {
+        columns.push(column)
+      }
+      let properties = []
+      for(let i=0; i<contents[0].values.length; i++) {
+        let values = contents[0].values[i];
+        let o = { attributes: {} }
+        for(let j=0; j<columns.length; j++) {
+          let column = columns[j]
+          if (["id", "name", "description", "image", "blockHash", "blockNumber", "self", "transactionHash", "uri"].includes(column)) {
+            o[column] = values[j]
+          } else {
+            o.attributes[column] = values[j]
+          }
         }
+        properties.push(o)
       }
-      properties.push(o)
-    }
-    let html = properties.map((p) => {
-      let attributes = p.attributes
-      let keys = Object.keys(attributes)
-      let table = keys.map((key) => {
-        return `<tr class='row' data-key='${key}' data-val='${attributes[key]}'><td>${key}</td><td>${attributes[key]}</td></tr>`
-      }).join("")
-      let img
-      if (p.image.startsWith("http")) {
-        img = "files/" + p.image.split("")
-          .map(c => c.charCodeAt(0).toString(16).padStart(2, "0"))
-          .join("");
-      } else {
-        img = "ipfs/" + p.image.replace("ipfs://", "")
-      }
+      html = properties.map((p) => {
+        let attributes = p.attributes
+        let keys = Object.keys(attributes)
+        let table = keys.map((key) => {
+          return `<tr class='row' data-key='${key}' data-val='${attributes[key]}'><td>${key}</td><td>${attributes[key]}</td></tr>`
+        }).join("")
+        let img
+        if (p.image.startsWith("http")) {
+          img = "files/" + p.image.split("")
+            .map(c => c.charCodeAt(0).toString(16).padStart(2, "0"))
+            .join("");
+        } else {
+          img = "ipfs/" + p.image.replace("ipfs://", "")
+        }
 
-      return `<div class='item'>
-<img src="${img}">
-<table>${table}</table>
-</div>`
-    }).join("")
+        return `<div class='item'>
+  <img src="${img}">
+  <table>${table}</table>
+  </div>`
+      }).join("")
+    }
     document.querySelector(".container").innerHTML = html
   }
 }


### PR DESCRIPTION
The user experience for when the query doesn't return any results could be improved. Currently the shown results remain displayed and the console shows the error:

```
(index):253 Uncaught TypeError: Cannot read properties of undefined (reading 'columns')
    at Loader.next ((index):253:35)
```

This is because when no results are returned, the `contents` array is empty in the following line

https://github.com/mixtape-network/mferbase/blob/4ec815a841baa951490d2079552f538a68c59cb3/index.html#L253

Here is an example of a query to reproduce this:

```
"chain" is not null
and "4:20 watch" is not null
and "hat under headphones" is not null
and "long hair" is not null
and "smoke" is not null
and "beard" is not null
and "shirt" is not null
```

This is also problematic since if there is a SQL error, the same thing happens, so in the case of "no results" it's not clear if there is a problem with the query or simply there were no results returned.

This PR does the following:

- Add a condition to check if the `contents` array is empty or not.
- If `contents` is empty then it assigns "No results" to the `html` var.
- If it's not empty it does what it currently does, i.e. construct the results table.