### PR TITLE
Add link to OpenSea

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,8 @@ class Loader {
     this.db = new SQL.Database(new Uint8Array(buf));
   }
   next() {
+    const openseaUrlPrefix = "https://opensea.io/assets"
+    const mfersContractAddress = "0x79fcdef22feed20eddacbb2587640e45491b757f"
     let select = document.querySelector("#select").value
     if (select.length === 0) {
       select = "*"
@@ -287,7 +289,7 @@ class Loader {
         }
 
         return `<div class='item'>
-  <img src="${img}">
+  <a target=”_blank” href="${openseaUrlPrefix}/${mfersContractAddress}/${p["id"]}"><img src="${img}"></a>
   <table>${table}</table>
   </div>`
       }).join("")


### PR DESCRIPTION
Add a link to the images to the OpenSea page of the NFT item.

@skogard I hesitated between OpenSea and Looksrare, I personally would rather give more visibility and encourage Looksrare, but thought people would prefer generally OpenSea as it has more sale info.. Let me know if you think linking to Looksrare would be better and I can change it.